### PR TITLE
Fix for github block-pio-sifive issue #47

### DIFF
--- a/docs/scribble/document/util/RegisterWrapper.py
+++ b/docs/scribble/document/util/RegisterWrapper.py
@@ -41,14 +41,14 @@ class RegisterMap:
         # Using the OM register map, create our our own register map
         self.register_map = RegMap.from_object_model(map)
 
-    def table(self, caption: str, refid: str = "") -> Table:
+    def table(self, title: str = None, refid: str = None) -> Table:
         """
         Create a register map table showing an overview of the registers
         """
-        table = self.register_map.get_register_map_table(caption, refid)
+        table = self.register_map.get_register_map_table(title, refid)
         return table
 
-    def fields(self, name: str, refid: str = "") -> Table:
+    def fields(self, name: str, refid: str = None) -> Table:
         """
         Create a table of fields for the given register.
         """

--- a/docs/scribble/document/util/RegisterWrapper.py
+++ b/docs/scribble/document/util/RegisterWrapper.py
@@ -41,10 +41,15 @@ class RegisterMap:
         # Using the OM register map, create our our own register map
         self.register_map = RegMap.from_object_model(map)
 
-    def table(self, title: str = None, refid: str = None) -> Table:
+    def table(self, title: str = None, refid: str = None, caption: str = None) -> Table:
         """
         Create a register map table showing an overview of the registers
         """
+
+        # For backwards compatibilty, allow parameter name "caption" as an alias to "title"
+        title = title or caption
+
+        # Now, create the table.
         table = self.register_map.get_register_map_table(title, refid)
         return table
 


### PR DESCRIPTION
When the register map parameter "title" was renamed to "caption", not all the references were updated. Resulted in the "default" onboarding document breaking.
  - Restores name of parameter to "title", consistent with AsciiDoc conventions and other Scribble tables. and figures.

This PR will bump the release number. The wit manifests in block-pio-sifive must be updated for both master and preonboard branches.
