### PR TITLE
Exclude BusMemories from the document.

### DIFF
--- a/docs/scribble/document/Onboarding/Onboarding.py
+++ b/docs/scribble/document/Onboarding/Onboarding.py
@@ -38,7 +38,7 @@ def Onboarding(element: Element, **context) -> Text:
     devices = (
         QueryStream(document.design.components)
         .is_instance("Device")
-        .is_not_instance("Core", "CLINT", "Debug")
+        .is_not_instance("Core", "CLINT", "Debug", "BusMemory")
     )
     deviceGroups = devices.sorted(key=memory_order).grouped_by(primary_type)
 


### PR DESCRIPTION
https://github.com/sifive/block-pio-sifive/pull/48#issuecomment-564867954 is currently failing documentation generation because a new Object Model component is being added for the memories, but the default templates don't handle it correctly.

The source of this error is the fact that https://github.com/sifive/block-pio-sifive/pull/48 points to https://github.com/sifive/soc-testsocket-sifive/pull/9, which emits a new OMBusMemory device corresponding to a TLRAM in the TestSocket. This OMBusMemory is a subtype of OMDevice, which is causing it to get picked up in the scribble-testsocket-sifive document. This OMBusMemory lacks any registers, since it is a just a plain memory, so the default documentation templates are failing when they attempt to render the register map.

This really isn't something that we need to be including in the TestSocket onboarding documentation anyway, so this PR adds `BusMemory` to the list of excluded device types.