### PR TITLE
Exclude ErrorDevice from document.

### DIFF
--- a/docs/scribble/document/Onboarding/Onboarding.py
+++ b/docs/scribble/document/Onboarding/Onboarding.py
@@ -38,7 +38,7 @@ def Onboarding(element: Element, **context) -> Text:
     devices = (
         QueryStream(document.design.components)
         .is_instance("Device")
-        .is_not_instance("Core", "CLINT", "Debug", "BusMemory")
+        .is_not_instance("Core", "CLINT", "Debug", "BusMemory", "ErrorDevice")
     )
     deviceGroups = devices.sorted(key=memory_order).grouped_by(primary_type)
 


### PR DESCRIPTION
Fixes issue described in https://github.com/sifive/block-pio-sifive/pull/70#issuecomment-627487560.

Bumping to a newer soc-testsocket-sifive/rocket-chip causes the addition of an ErrorDevice object to appear in the Object Model, which lacks any registers. The scribble-testsocket-sifive logic is pretty naive for deciding which devices to actually render documentation for, and it locates the block under test by filtering out several component types that are known to be located in the test socket. This adds ErrorDevice to that blacklist.

Tested locally and confirmed that adding this allows the docs to build.