### PR TITLE
Bump to a version of scribble that supports wake 0.18.

### DIFF
--- a/wit-manifest.json
+++ b/wit-manifest.json
@@ -1,6 +1,6 @@
 [
     {
-        "commit": "a1b231242d0c7d1434131bed814f63d120b939cd",
+        "commit": "0dffc47bc513a80743ea162589846e655dc2944a",
         "name": "scribble",
         "source": "git@github.com:sifive/scribble.git"
     }


### PR DESCRIPTION
This bumps scribble to [v0.1.2](https://github.com/sifive/scribble/releases/tag/v0.1.2) for some Wake syntax updates. This otherwise has no functional change.