### PR TITLE
Add wake 0.19 CI type check

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,7 @@ on: [push, pull_request]
 jobs:
 
   typecheck:
-    name: 'Wake 0.18.1 typecheck'
+    name: 'Wake 0.19 typecheck'
     runs-on: ubuntu-latest
     env:
       # $WIT_WORKSPACE path is relative to $GITHUB_WORKSPACE
@@ -37,7 +37,7 @@ jobs:
         gid=$(id -g)
         sudo chown -R "$uid:$gid" .
         # Install Wake
-        curl -L -o /tmp/wake.deb https://github.com/sifive/wake/releases/download/v0.18.1/ubuntu-18-04-wake_0.18.1-1_amd64.deb && \
+        curl -L -o /tmp/wake.deb https://github.com/sifive/wake/releases/download/v0.19.0/ubuntu-18-04-wake_0.19.0-1_amd64.deb && \
             sudo dpkg -i /tmp/wake.deb && \
             rm /tmp/wake.deb
         # Initialize Wake workspace

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,46 @@
+name: wake-api-test
+
+on: [push, pull_request]
+
+jobs:
+
+  typecheck:
+    name: 'Wake 0.18.1 typecheck'
+    runs-on: ubuntu-latest
+    env:
+      # $WIT_WORKSPACE path is relative to $GITHUB_WORKSPACE
+      WIT_WORKSPACE: wit-workspace
+
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        path: wit-packages/scribble-testsocket-sifie
+        # Fetch all history and tags
+        fetch-depth: 0
+
+    - name: 'Wit Init'
+      uses: sifive/wit/actions/wit@v0.13.1
+      with:
+        command: init
+        arguments: |
+          ${{ env.WIT_WORKSPACE }}
+          -a ./wit-packages/scribble-testsocket-sifie
+        force_github_https: true
+
+    - name: Run wake typecheck
+      working-directory: ${{ env.WIT_WORKSPACE }}
+      run: |
+        set -euxo pipefail
+        # Take back ownership of wit workspace, since it was created while
+        # under a Docker container and permissions default to root.
+        uid=$(id -u)
+        gid=$(id -g)
+        sudo chown -R "$uid:$gid" .
+        # Install Wake
+        curl -L -o /tmp/wake.deb https://github.com/sifive/wake/releases/download/v0.18.1/ubuntu-18-04-wake_0.18.1-1_amd64.deb && \
+            sudo dpkg -i /tmp/wake.deb && \
+            rm /tmp/wake.deb
+        # Initialize Wake workspace
+        wake --init .
+        # Run a dummy target, which still triggers a compilation of Wake code.
+        wake -x Unit

--- a/wit-manifest.json
+++ b/wit-manifest.json
@@ -1,6 +1,6 @@
 [
     {
-        "commit": "0dffc47bc513a80743ea162589846e655dc2944a",
+        "commit": "f30c6bb176cb5a434c3c408173b5f9b46c75a2d8",
         "name": "scribble",
         "source": "git@github.com:sifive/scribble.git"
     }


### PR DESCRIPTION
Similar to the other PRs we've been making. This also required a bump to `scribble` itself to pull in a version new enough to have wake ~0.18~ 0.19 changes.